### PR TITLE
Items single finder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,34 @@
+require: rubocop-rails
+
+AllCops:
+  Exclude:
+    - 'bin/**/*'
+    - 'config/**/*'
+    - 'coverage/**/*'
+    - 'db/**/*'
+    - 'lib/**/*'
+    - 'log/**/*'
+    - 'node_modules/**/*'
+    - 'public/**/*'
+    - 'spec/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+    - './*'
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Rails/UniqueValidationWithoutIndex:
+  Enabled: false

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Items::SearchController < ApplicationController
+  def show
+    render json: ItemSerializer.new(Item.search(permitted_params))
+  end
+
+  private
+
+  def permitted_params
+    params.permit(:name, :id, :unit_price, :description, :created_at, :updated_at, :merchant_id)
+  end
+end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::ItemsController < ApplicationController
   def destroy
     Item.destroy(params[:id])
   end
-  
+
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,12 +6,12 @@ class Item < ApplicationRecord
   has_many :invoices, through: :invoice_items
   has_many :transactions, through: :invoices
 
-  scope :find_by_date, -> (param) {where("to_char(#{param.keys.first},'YYYY-MM-DD-HH-MI-SS') ILIKE ?", "%#{param.values.first}%")}
-  scope :find_by_attribute, -> (param) {where("items.#{param.keys.first}::text ILIKE ?", "%#{param.values.first}%")}
+  scope :find_by_date, ->(param) { where("to_char(#{param.keys.first},'YYYY-MM-DD-HH-MI-SS') ILIKE ?", "%#{param.values.first}%") }
+  scope :find_by_attribute, ->(param) { where("items.#{param.keys.first}::text ILIKE ?", "%#{param.values.first}%") }
 
   def self.search(param)
     attribute = param.keys.first
-    if attribute == 'created_at' || attribute == 'updated_at'
+    if %w[created_at updated_at].include?(attribute)
       find_by_date(param).first
     else
       find_by_attribute(param).first

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,4 +5,16 @@ class Item < ApplicationRecord
   has_many :invoice_items, dependent: :destroy
   has_many :invoices, through: :invoice_items
   has_many :transactions, through: :invoices
+
+  scope :find_by_date, -> (param) {where("to_char(#{param.keys.first},'YYYY-MM-DD-HH-MI-SS') ILIKE ?", "%#{param.values.first}%")}
+  scope :find_by_attribute, -> (param) {where("items.#{param.keys.first}::text ILIKE ?", "%#{param.values.first}%")}
+
+  def self.search(param)
+    attribute = param.keys.first
+    if attribute == 'created_at' || attribute == 'updated_at'
+      find_by_date(param).first
+    else
+      find_by_attribute(param).first
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
       namespace :items do
         get '/:id/merchants', to: 'merchants#index'
+        get '/find', to: 'search#show'
       end
 
       namespace :merchants do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,4 +12,17 @@ RSpec.describe Item, type: :model do
     it { should have_many :invoice_items }
     it { should have_many(:invoices).through(:invoice_items) }
   end
+
+  describe 'Methods' do
+    it ".search()" do
+      item = create(:item, name: "unIque nAme")
+      item_2 = create(:item, description: "unique Description")
+
+      param = {"name"=>"unIque nAme"}
+      param_2 = {"description"=>"unique Description"}
+
+      expect(Item.search(param)).to eq(item)
+      expect(Item.search(param_2)).to eq(item_2)
+    end
+  end
 end

--- a/spec/requests/api/v1/items/single_finder_spec.rb
+++ b/spec/requests/api/v1/items/single_finder_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Single Find feature' do
-  it 'can search for an item by name ' do
-    item = create(:item, name: "Unique Name")
+  it 'can search for an item by name, case insensitive' do
+    item = create(:item, name: "unIque nAme")
     create_list(:item, 2)
 
     attribute = "name"
@@ -23,8 +23,8 @@ RSpec.describe 'Single Find feature' do
     expect(item_json[:data][:attributes][:merchant_id]).to eq(item.merchant_id)
   end
 
-  it 'can search for an item by description' do
-    item = create(:item, description: "Unique description")
+  it 'can search for an item by description, case insensitive' do
+    item = create(:item, description: "unique Description")
     create_list(:item, 2)
 
     attribute = "description"

--- a/spec/requests/api/v1/items/single_finder_spec.rb
+++ b/spec/requests/api/v1/items/single_finder_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Single Find feature' do
-  it 'can search for an item by name, case insensitive' do
+  it 'can search for an item by name, case insensitive or partial match' do
     item = create(:item, name: "unIque nAme")
     create_list(:item, 2)
 
     attribute = "name"
+    query = "Ique"
 
-    get "/api/v1/items/find?#{attribute}=#{item.name}"
+    get "/api/v1/items/find?#{attribute}=#{query}"
     item_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
@@ -23,13 +24,14 @@ RSpec.describe 'Single Find feature' do
     expect(item_json[:data][:attributes][:merchant_id]).to eq(item.merchant_id)
   end
 
-  it 'can search for an item by description, case insensitive' do
+  it 'can search for an item by description, case insensitive, or partial match' do
     item = create(:item, description: "unique Description")
     create_list(:item, 2)
 
     attribute = "description"
+    query = "ique"
 
-    get "/api/v1/items/find?#{attribute}=#{item.description}"
+    get "/api/v1/items/find?#{attribute}=#{query}"
     item_json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful

--- a/spec/requests/api/v1/items/single_finder_spec.rb
+++ b/spec/requests/api/v1/items/single_finder_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe 'Single Find feature' do
+  it 'can search for an item by name ' do
+    item = create(:item, name: "Unique Name")
+    create_list(:item, 2)
+
+    attribute = "name"
+
+    get "/api/v1/items/find?#{attribute}=#{item.name}"
+    item_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(item_json.size).to eq(1)
+    expect(item_json.class).to eq(Hash)
+    expect(item_json[:data][:id]).to eq("#{item.id}")
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:attributes][:name]).to eq(item.name)
+    expect(item_json[:data][:attributes][:unit_price]).to eq(item.unit_price)
+    expect(item_json[:data][:attributes][:description]).to eq(item.description)
+    expect(item_json[:data][:attributes][:merchant_id]).to eq(item.merchant_id)
+  end
+
+  it 'can search for an item by description' do
+    item = create(:item, description: "Unique description")
+    create_list(:item, 2)
+
+    attribute = "description"
+
+    get "/api/v1/items/find?#{attribute}=#{item.description}"
+    item_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(item_json.size).to eq(1)
+    expect(item_json.class).to eq(Hash)
+    expect(item_json[:data][:id]).to eq("#{item.id}")
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:attributes][:name]).to eq(item.name)
+  end
+
+  it 'can search for an item by unit price' do
+    item = create(:item, unit_price: 1234.56)
+    create_list(:item, 2)
+
+    attribute = "unit_price"
+
+    get "/api/v1/items/find?#{attribute}=#{item.unit_price}"
+    item_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(item_json.size).to eq(1)
+    expect(item_json.class).to eq(Hash)
+    expect(item_json[:data][:id]).to eq("#{item.id}")
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:attributes][:unit_price]).to eq(item.unit_price)
+  end
+
+  it 'can search for an item by created_at' do
+    item = create(:item, created_at: "'Fri, 3 Dec 2020 8:00:00 UTC +00:00'")
+    create(:item, created_at: "'Fri, 4 Dec 2020 8:00:00 UTC +00:00'")
+
+    attribute = "created_at"
+    query = "3"
+
+    get "/api/v1/items/find?#{attribute}=#{query}"
+    item_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(item_json.size).to eq(1)
+    expect(item_json.class).to eq(Hash)
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:id]).to eq("#{item.id}")
+  end
+
+  it 'can search for an item by updated_at' do
+    item = create(:item, updated_at: "'Fri, 3 Dec 2020 8:00:00 UTC +00:00'")
+    create(:item, created_at: "'Fri, 4 Dec 2020 8:00:00 UTC +00:00'")
+
+    attribute = "updated_at"
+    query = "3"
+
+    get "/api/v1/items/find?#{attribute}=#{query}"
+    item_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(item_json.size).to eq(1)
+    expect(item_json.class).to eq(Hash)
+    expect(item_json[:data][:type]).to eq('item')
+    expect(item_json[:data][:id]).to eq("#{item.id}")
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added the functionality to search for an item by any of its attributes. Case insensitive and /or partial match works as well when searching by name or description. 


## Description
<!--- Describe your changes in detail -->

- Rough draft out a spec for single find endpoint for items
- Under namespace items, add a /find that goes to an items search controller
- Add scopes and search method inside item model
- Create items search controlller with show method
- Test search can be case insensitive
- Test search method in item model spec
- Update spec to test search can include partial matches for both query by name and query by description

Rubocop
- Add rubocop yml file
- Correct rubocop offenses


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This endpoint should return a single record that matches a set of criteria. Criteria will be input through query parameters.

## Closes 
<!--- List issues this pull request closes-->
Closes #17 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Spec called single_finder_spec.rb created in spec/requests/api/v1/items
- Tested new model method in item model spec

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
