### PR TITLE
Merchants single finder

### DIFF
--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Merchants::SearchController < ApplicationController
+  def show
+    render json: MerchantSerializer.new(Merchant.search(permitted_params))
+  end
+
+  private
+
+  def permitted_params
+    params.permit(:name, :id, :created_at, :updated_at)
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -4,4 +4,16 @@ class Merchant < ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :invoices, dependent: :destroy
   has_many :transactions, through: :invoices
+
+  scope :find_by_date, ->(param) { where("to_char(#{param.keys.first},'YYYY-MM-DD-HH-MI-SS') ILIKE ?", "%#{param.values.first}%") }
+  scope :find_by_attribute, ->(param) { where("merchants.#{param.keys.first}::text ILIKE ?", "%#{param.values.first}%") }
+
+  def self.search(param)
+    attribute = param.keys.first
+    if %w[created_at updated_at].include?(attribute)
+      find_by_date(param).first
+    else
+      find_by_attribute(param).first
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
       namespace :merchants do
         get '/:id/items', to: 'items#index'
+        get '/find', to: 'search#show'
       end
 
 

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -9,4 +9,17 @@ RSpec.describe Merchant, type: :model do
     it { should have_many :invoices }
     it { should have_many(:transactions).through(:invoices) }
   end
+
+  describe 'Methods' do
+    it ".search()" do
+      merchant = create(:merchant, name: "unIque nAme")
+      merchant_2 = create(:merchant, id: 2)
+
+      param = {"name"=>"unIque nAme"}
+      param_2 = {"id"=>"2"}
+
+      expect(Merchant.search(param)).to eq(merchant)
+      expect(Merchant.search(param_2)).to eq(merchant_2)
+    end
+  end
 end

--- a/spec/requests/api/v1/merchants/single_finder_spec.rb
+++ b/spec/requests/api/v1/merchants/single_finder_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe 'Single Find feature' do
+  it 'can search for a merchant by name, case insensitive or partial match' do
+    merchant = create(:merchant, name: "unIque nAme")
+    create_list(:merchant, 2)
+
+    attribute = "name"
+    query = "Ique"
+
+    get "/api/v1/merchants/find?#{attribute}=#{query}"
+    merchant_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(merchant_json.size).to eq(1)
+    expect(merchant_json.class).to eq(Hash)
+    expect(merchant_json[:data][:type]).to eq('merchant')
+    expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
+    expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)
+  end
+
+  it 'can search for a merchant by id' do
+    merchant = create(:merchant)
+    create_list(:merchant, 2)
+
+    attribute = "id"
+    query = "#{merchant.id}"
+
+    get "/api/v1/merchants/find?#{attribute}=#{query}"
+    merchant_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(merchant_json.size).to eq(1)
+    expect(merchant_json.class).to eq(Hash)
+    expect(merchant_json[:data][:type]).to eq('merchant')
+    expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
+    expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)
+  end
+
+  it 'can search for a merchant by created_at' do
+    merchant = create(:merchant, created_at: "'Fri, 3 Dec 2020 8:00:00 UTC +00:00'")
+               create(:merchant, created_at: "'Fri, 4 Dec 2020 8:00:00 UTC +00:00'")
+
+    attribute = "created_at"
+    query = "3"
+
+    get "/api/v1/merchants/find?#{attribute}=#{query}"
+    merchant_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(merchant_json.size).to eq(1)
+    expect(merchant_json.class).to eq(Hash)
+    expect(merchant_json[:data][:type]).to eq('merchant')
+    expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
+    expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)
+  end
+
+  it 'can search for a merchant by updated_at' do
+    merchant = create(:merchant, updated_at: "'Fri, 3 Dec 2020 8:00:00 UTC +00:00'")
+               create(:merchant, updated_at: "'Fri, 4 Dec 2020 8:00:00 UTC +00:00'")
+
+    attribute = "updated_at"
+    query = "3"
+
+    get "/api/v1/merchants/find?#{attribute}=#{query}"
+    merchant_json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq("application/json")
+
+    expect(merchant_json.size).to eq(1)
+    expect(merchant_json.class).to eq(Hash)
+    expect(merchant_json[:data][:type]).to eq('merchant')
+    expect(merchant_json[:data][:id]).to eq("#{merchant.id}")
+    expect(merchant_json[:data][:attributes][:name]).to eq(merchant.name)
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added the functionality to search for a merchant by it's name, id, created_at, or updated_at attributes. Case insensitive and /or partial match works as well when searching by name.

## Description
<!--- Describe your changes in detail -->
- Create spec for single finder endpoint with tests
- Within namespace merchants, add /find to search show
- Add test for new search method in merchant model
- Add search method and scopes
- Create merchant search controller with show method


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This endpoint should return a single record that matches a set of criteria. Criteria will be input through query parameters.

## Closes 
<!--- List issues this pull request closes-->
Closes #18 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Spec called single_finder_spec.rb created in spec/requests/api/v1/merchants
- Tested new model method in merchant model spec


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
